### PR TITLE
Use a dynamic version in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In your `extra` section add the following:
 ```json
 {
     "require": {
-        "foo/bar": "0.1.0",
+        "foo/bar": "^0.1.0",
         "openeuropa/composer-artifacts": "*"
     },    
     "extra": {


### PR DESCRIPTION
The example in the README uses a locked version, this is very unusual and gives the impression that this plugin can only be used with fixed versions.