### PR TITLE
OPENEUROPA-1897: Use ci image.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,14 +4,14 @@ workspace:
 
 services:
   web:
-    image: fpfis/httpd-php-dev:${PHP_VERSION=5.6}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=5.6}
     environment:
       - DOCUMENT_ROOT=/test/composer-artifacts
 
 pipeline:
   composer-install-lowest:
     group: prepare
-    image: fpfis/httpd-php-dev:${PHP_VERSION=5.6}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=5.6}
     volumes:
     - /cache:/cache
     commands:
@@ -25,7 +25,7 @@ pipeline:
 
   composer-install-highest:
     group: prepare
-    image: fpfis/httpd-php-dev:${PHP_VERSION=5.6}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=5.6}
     volumes:
     - /cache:/cache
     commands:
@@ -36,13 +36,13 @@ pipeline:
 
   grumphp:
     group: test
-    image: fpfis/httpd-php-dev:${PHP_VERSION=5.6}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=5.6}
     commands:
     - ./vendor/bin/grumphp run
 
   phpunit:
     group: test
-    image: fpfis/httpd-php-dev:${PHP_VERSION=5.6}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=5.6}
     commands:
     - ./vendor/bin/phpunit
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,9 @@
         }
     },
     "extra": {
-        "class": "OpenEuropa\\ComposerArtifacts\\Plugin"
+        "class": "OpenEuropa\\ComposerArtifacts\\Plugin",
+        "enable-patching": true,
+        "composer-exit-on-patch-failure": true
     },
     "config": {
         "sort-packages": true

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -128,8 +128,8 @@ class PluginTest extends TestCase
         $plugin->activate($composer, $io);
 
         $operation = 'install' === $operationName ?
-            new InstallOperation($package) :
-            new UpdateOperation($package, $package);
+        new InstallOperation($package) :
+        new UpdateOperation($package, $package);
 
         return [
             'event' => new PackageEvent(


### PR DESCRIPTION
## OPENEUROPA-1897
### Description

Use CI image on drone builds.

### Change log

- Added:
- Changed: Use CI image on drone builds.

- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

