### PR TITLE
OPENEUROPA-2258: Use PHP 7.2 in drone and docker image.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -50,6 +50,7 @@ matrix:
   PHP_VERSION:
     - 5.6
     - 7.1
+    - 7.2
   COMPOSER_BOUNDARY:
     - lowest
     - highest

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,14 +4,14 @@ workspace:
 
 services:
   web:
-    image: fpfis/httpd-php-ci:${PHP_VERSION=5.6}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     environment:
       - DOCUMENT_ROOT=/test/composer-artifacts
 
 pipeline:
   composer-install-lowest:
     group: prepare
-    image: fpfis/httpd-php-ci:${PHP_VERSION=5.6}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     volumes:
     - /cache:/cache
     commands:
@@ -25,7 +25,7 @@ pipeline:
 
   composer-install-highest:
     group: prepare
-    image: fpfis/httpd-php-ci:${PHP_VERSION=5.6}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     volumes:
     - /cache:/cache
     commands:
@@ -36,19 +36,18 @@ pipeline:
 
   grumphp:
     group: test
-    image: fpfis/httpd-php-ci:${PHP_VERSION=5.6}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     commands:
     - ./vendor/bin/grumphp run
 
   phpunit:
     group: test
-    image: fpfis/httpd-php-ci:${PHP_VERSION=5.6}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     commands:
     - ./vendor/bin/phpunit
 
 matrix:
   PHP_VERSION:
-    - 5.6
     - 7.1
     - 7.2
   COMPOSER_BOUNDARY:

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,16 @@
     },
     "require-dev": {
         "composer/composer": "~1.4",
+        "cweagans/composer-patches": "^1.6",
         "openeuropa/code-review": "~1.0.0-alpha3",
         "phpunit/phpunit": "~5.5||~6.0",
+        "sebastian/comparator": "^1.2.4",
         "symfony/yaml": "~3.4"
     },
+    "_readme": [
+        "We explicitly require cweagans/composer-patches to allow 'composer update --prefer-lowest' to complete successfully.",
+        "We explicitly require sebastian/comparator to allow phpunit tests after 'composer update --prefer-lowest' to complete successfully."
+    ],
     "autoload": {
         "psr-4": {
             "OpenEuropa\\ComposerArtifacts\\": "./src/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   web:
-    image: fpfis/httpd-php-dev:7.1
+    image: fpfis/httpd-php-dev:7.2
     working_dir: /var/www/html
     ports:
       - 8080:8080


### PR DESCRIPTION
## OPENEUROPA-2258

### Description

Use PHP 7.2 in drone and docker image.

### Change log

- Added: PHP 7.2 usage in docker-compose and drone.